### PR TITLE
Fix dev check for Theatre Studio

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5,9 +5,9 @@ import {getProject, types as t} from "@theatre/core"
 import studio from '@theatre/studio';
 // import state from './state.json'
 
-// Only initialises Studio on development mode 
-if (import.meta.env.DEV) {
-studio.initialize()
+// Only initialise Studio in development mode
+if (import.meta.env.MODE === 'development') {
+  studio.initialize()
 }
 // To hide/show the UI pressing alt + \
 studio.ui.hide()


### PR DESCRIPTION
## Summary
- ensure Theatre Studio only initializes in development using `import.meta.env.MODE`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685828ef83cc832085ab0ba3ec8b9bb2